### PR TITLE
Add unittests

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,4 +1,5 @@
-run = ["cargo", "run"]
+# run = ["cargo", "run"]
+run = "cargo run && cargo test"
 
 entrypoint = "src/main.rs"
 

--- a/.replit
+++ b/.replit
@@ -3,6 +3,8 @@ run = "cargo run && cargo test"
 
 entrypoint = "src/main.rs"
 
+hidden = ["target", ".git", ".config"]
+
 [packager]
 language = "rust"
 

--- a/replit.nix
+++ b/replit.nix
@@ -1,6 +1,7 @@
 { pkgs }: {
 	deps = [
-		pkgs.rustc
+		pkgs.htop
+  pkgs.rustc
 		pkgs.rustfmt
 		pkgs.cargo
 		pkgs.cargo-edit

--- a/replit.nix
+++ b/replit.nix
@@ -1,7 +1,7 @@
 { pkgs }: {
 	deps = [
 		pkgs.htop
-  pkgs.rustc
+        pkgs.rustc
 		pkgs.rustfmt
 		pkgs.cargo
 		pkgs.cargo-edit

--- a/replit.nix
+++ b/replit.nix
@@ -1,7 +1,7 @@
 { pkgs }: {
 	deps = [
 		pkgs.htop
-        pkgs.rustc
+		pkgs.rustc
 		pkgs.rustfmt
 		pkgs.cargo
 		pkgs.cargo-edit

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,72 +1,73 @@
 pub mod network;
 pub mod node;
 pub mod sigmoid;
-#[cfg(test)]
-mod test_util;
 pub mod training_data;
 mod util;
 
-use crate::network::Network;
-use crate::node::NodeLike;
+#[cfg(test)]
+mod test_util;
 
-macro_rules! assert_cached_eq {
-    ($network:expr, $ni:expr, $li:expr, $val:expr) => {
-        assert_eq!(
-            *$network.get_main_node($ni, $li).result_cache.borrow(),
-            $val
-        )
-    };
-    ($cache:expr, $val:expr) => {
-        assert_eq!(*$cache.borrow(), $val)
-    };
+#[cfg(test)]
+mod main_tests {
+    use crate::network::Network;
+    use crate::node::NodeLike;
+    use crate::test_util::assert_refcell_eq;
+    
+    macro_rules! assert_cached_eq {
+        ($network:expr, $ni:expr, $li:expr, $val:expr) => {
+            assert_eq!(
+                *$network.get_main_node($ni, $li).result_cache.borrow(),
+                $val
+            )
+        };
+        ($cache:expr, $val:expr) => {
+            assert_eq!(*$cache.borrow(), $val)
+        };
+    }
+
+    #[test]
+    fn run_checks() {
+        // NOTE TO SELF: remember that activation is passed thru sigmoid activation
+        // DONT FORGET THIS when writing tests and wondering why they fail
+        let mut nw = Network::new(&vec![2, 2]);
+        // println!("{:#?}", nw);
+        assert_cached_eq!(nw, 1, 1, None);
+        let v = nw.get_node(1, 1).get_value(&nw);
+        assert_eq!(v, 0.5); // (0.0).sigmoid()
+        assert_cached_eq!(nw, 1, 1, Some(v));
+        nw.get_start_node_mut(1).set_value(1.0);
+        assert_eq!(nw.get_start_node(1).value, 1.0);
+        nw.get_main_node_mut(1, 1).set_weight(1, 1.0);
+        // NOTE: the reason its commented out is
+        // because i might want set_weight to invalidate cache
+        // assert_eq!(*nw.get_main_node(1, 1).result_cache.borrow(), Some(v));
+        assert_eq!(nw.get_main_node(1, 1).get_weight(1), 1.0);
+        nw.get_main_node(1, 1).invalidate();
+        assert_cached_eq!(nw, 1, 1, None);
+        let v = nw.get_main_node(1, 1).get_value(&nw);
+        assert_eq!(v, 0.7310585786300049);
+        assert_cached_eq!(nw, 1, 1, Some(v));
+        assert_cached_eq!(nw.get_main_node(1, 1).sum_cache, Some(1.));
+        assert_eq!(nw.get_current_cost(&vec![0.5, 1.0]), 0.07232948812851325);
+        nw.train_on_current_data(&vec![0.5, 0.5]);
+        assert_refcell_eq!(nw.get_main_node(1, 1).requested_nudge, -0.4621171572600098);
+        assert_refcell_eq!(
+            nw.get_main_node(1, 1).inp_w_nudge_sum,
+            vec![0.0, -0.3378347121470412]
+        );
+        assert_refcell_eq!(nw.get_main_node(1, 1).bias_nudge_sum, -0.3378347121470412);
+        assert_refcell_eq!(nw.get_main_node(1, 1).nudge_cnt, 1);
+        nw.apply_nudges();
+        assert_refcell_eq!(nw.get_main_node(1, 1).inp_w_nudge_sum, vec![0.0; 2]);
+        assert_refcell_eq!(nw.get_main_node(1, 1).bias_nudge_sum, 0.0);
+        assert_refcell_eq!(nw.get_main_node(1, 1).nudge_cnt, 0);
+        assert_refcell_eq!(nw.get_main_node(1, 1).requested_nudge, 0.0);
+        println!("{:#?}", nw);
+    }
 }
 
-macro_rules! assert_refcell_eq {
-    ($refcell: expr, $value: expr) => {
-        assert_eq!(*$refcell.borrow(), $value)
-    };
-}
 
-fn run_checks() {
-    // NOTE TO SELF: remember that activation is passed thru sigmoid activation
-    // DONT FORGET THIS when writing tests and wondering why they fail
-    let mut nw = Network::new(&vec![2, 2]);
-    // println!("{:#?}", nw);
-    assert_cached_eq!(nw, 1, 1, None);
-    let v = nw.get_node(1, 1).get_value(&nw);
-    assert_eq!(v, 0.5); // (0.0).sigmoid()
-    assert_cached_eq!(nw, 1, 1, Some(v));
-    nw.get_start_node_mut(1).set_value(1.0);
-    assert_eq!(nw.get_start_node(1).value, 1.0);
-    nw.get_main_node_mut(1, 1).set_weight(1, 1.0);
-    // NOTE: the reason its commented out is
-    // because i might want set_weight to invalidate cache
-    // assert_eq!(*nw.get_main_node(1, 1).result_cache.borrow(), Some(v));
-    assert_eq!(nw.get_main_node(1, 1).get_weight(1), 1.0);
-    nw.get_main_node(1, 1).invalidate();
-    assert_cached_eq!(nw, 1, 1, None);
-    let v = nw.get_main_node(1, 1).get_value(&nw);
-    assert_eq!(v, 0.7310585786300049);
-    assert_cached_eq!(nw, 1, 1, Some(v));
-    assert_cached_eq!(nw.get_main_node(1, 1).sum_cache, Some(1.));
-    assert_eq!(nw.get_current_cost(&vec![0.5, 1.0]), 0.07232948812851325);
-    nw.train_on_current_data(&vec![0.5, 0.5]);
-    assert_refcell_eq!(nw.get_main_node(1, 1).requested_nudge, -0.4621171572600098);
-    assert_refcell_eq!(
-        nw.get_main_node(1, 1).inp_w_nudge_sum,
-        vec![0.0, -0.3378347121470412]
-    );
-    assert_refcell_eq!(nw.get_main_node(1, 1).bias_nudge_sum, -0.3378347121470412);
-    assert_refcell_eq!(nw.get_main_node(1, 1).nudge_cnt, 1);
-    nw.apply_nudges();
-    assert_refcell_eq!(nw.get_main_node(1, 1).inp_w_nudge_sum, vec![0.0; 2]);
-    assert_refcell_eq!(nw.get_main_node(1, 1).bias_nudge_sum, 0.0);
-    assert_refcell_eq!(nw.get_main_node(1, 1).nudge_cnt, 0);
-    assert_refcell_eq!(nw.get_main_node(1, 1).requested_nudge, 0.0);
-    println!("{:#?}", nw);
-}
 
 fn main() {
     println!("Hello world!");
-    run_checks();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,9 @@ mod main_tests {
     fn run_checks() {
         // NOTE TO SELF: remember that activation is passed thru sigmoid activation
         // DONT FORGET THIS when writing tests and wondering why they fail
+        // NOTE TO SELF 2: These tests aren't as important as all the unittests 
+        // as the numbers here aren't actually checked to be correct
+        // they are just the result from the previous version
         let mut nw = Network::new(&vec![2, 2]);
         // println!("{:#?}", nw);
         assert_cached_eq!(nw, 1, 1, None);
@@ -53,9 +56,9 @@ mod main_tests {
         assert_refcell_eq!(nw.get_main_node(1, 1).requested_nudge, -0.4621171572600098);
         assert_refcell_eq!(
             nw.get_main_node(1, 1).inp_w_nudge_sum,
-            vec![0.0, -0.3378347121470412]
+            vec![0.0, -0.4621171572600098]
         );
-        assert_refcell_eq!(nw.get_main_node(1, 1).bias_nudge_sum, -0.3378347121470412);
+        assert_refcell_eq!(nw.get_main_node(1, 1).bias_nudge_sum, -0.4621171572600098);
         assert_refcell_eq!(nw.get_main_node(1, 1).nudge_cnt, 1);
         nw.apply_nudges();
         assert_refcell_eq!(nw.get_main_node(1, 1).inp_w_nudge_sum, vec![0.0; 2]);

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ mod main_tests {
     use crate::network::Network;
     use crate::node::NodeLike;
     use crate::test_util::assert_refcell_eq;
-    
+
     macro_rules! assert_cached_eq {
         ($network:expr, $ni:expr, $li:expr, $val:expr) => {
             assert_eq!(
@@ -29,7 +29,7 @@ mod main_tests {
     fn run_checks() {
         // NOTE TO SELF: remember that activation is passed thru sigmoid activation
         // DONT FORGET THIS when writing tests and wondering why they fail
-        // NOTE TO SELF 2: These tests aren't as important as all the unittests 
+        // NOTE TO SELF 2: These tests aren't as important as all the unittests
         // as the numbers here aren't actually checked to be correct
         // they are just the result from the previous version
         let mut nw = Network::new(&vec![2, 2]);
@@ -72,8 +72,6 @@ mod main_tests {
         println!("{:#?}", nw);
     }
 }
-
-
 
 fn main() {
     println!("Hello world!");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
 pub mod network;
 pub mod node;
 pub mod sigmoid;
-pub mod training_data;
 #[cfg(test)]
 mod test_util;
+pub mod training_data;
 mod util;
 
 use crate::network::Network;

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,15 +56,19 @@ mod main_tests {
         assert_refcell_eq!(nw.get_main_node(1, 1).requested_nudge, -0.4621171572600098);
         assert_refcell_eq!(
             nw.get_main_node(1, 1).inp_w_nudge_sum,
-            vec![0.0, -0.4621171572600098]
+            vec![0.0, -0.09085774767294842]
         );
-        assert_refcell_eq!(nw.get_main_node(1, 1).bias_nudge_sum, -0.4621171572600098);
+        assert_refcell_eq!(nw.get_main_node(1, 1).bias_nudge_sum, -0.09085774767294842);
         assert_refcell_eq!(nw.get_main_node(1, 1).nudge_cnt, 1);
         nw.apply_nudges();
         assert_refcell_eq!(nw.get_main_node(1, 1).inp_w_nudge_sum, vec![0.0; 2]);
         assert_refcell_eq!(nw.get_main_node(1, 1).bias_nudge_sum, 0.0);
         assert_refcell_eq!(nw.get_main_node(1, 1).nudge_cnt, 0);
         assert_refcell_eq!(nw.get_main_node(1, 1).requested_nudge, 0.0);
+        // <> these values is correct and checked:
+        assert_eq!(nw.get_main_node(1, 1).bias, -0.09085774767294842);
+        assert_eq!(nw.get_main_node(1, 1).inp_w, vec![0.0, 0.9091422523270516]);
+        // </>
         println!("{:#?}", nw);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,9 @@ pub mod network;
 pub mod node;
 pub mod sigmoid;
 pub mod training_data;
-mod util;
 #[cfg(test)]
 mod test_util;
+mod util;
 
 use crate::network::Network;
 use crate::node::NodeLike;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,8 @@ pub mod node;
 pub mod sigmoid;
 pub mod training_data;
 mod util;
+#[cfg(test)]
+mod test_util;
 
 use crate::network::Network;
 use crate::node::NodeLike;

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,6 +1,6 @@
 use crate::node::{new_node, AnyNode, Node, StartNode};
+use crate::training_data::{TrainingData, TrainingExample};
 use crate::util::{error_deriv, error_f, TryIntoRef, TryIntoRefMut};
-use crate::training_data::{TrainingExample, TrainingData};
 
 pub type LayerT = Vec<AnyNode>;
 pub type NetworkLayersT = Vec<LayerT>;
@@ -37,7 +37,10 @@ impl Network {
 
     pub fn with_config(config: &NetworkConfig) -> Network {
         let config = config.clone();
-        assert!(config.shape.len() >= 2, "network must have at least start and end layers!");
+        assert!(
+            config.shape.len() >= 2,
+            "network must have at least start and end layers!"
+        );
         let layers = config
             .shape
             .iter()
@@ -150,9 +153,7 @@ impl Network {
     }
 
     pub fn train_on_batch(&mut self, batch: &TrainingData) {
-        batch.0.iter().for_each(|data| {
-            self.train_on_data(data)
-        });
+        batch.0.iter().for_each(|data| self.train_on_data(data));
         self.apply_nudges();
     }
 
@@ -162,7 +163,6 @@ impl Network {
         });
     }
 }
-
 
 // indexing stuff
 impl Network {
@@ -262,7 +262,8 @@ mod tests {
         let shape = vec![5, 3, 2];
         let nw = Network::new(&shape);
         nw.layers[0].iter().for_each(|n| {
-            n.try_into_ref::<StartNode>().expect("Start layer must only conatin start nodes");
+            n.try_into_ref::<StartNode>()
+                .expect("Start layer must only conatin start nodes");
         })
     }
     #[test]
@@ -271,7 +272,8 @@ mod tests {
         let nw = Network::new(&shape);
         nw.layers.iter().skip(1).for_each(|l| {
             l.iter().for_each(|n| {
-                n.try_into_ref::<Node>().expect("Main layer must only conatin main nodes");
+                n.try_into_ref::<Node>()
+                    .expect("Main layer must only conatin main nodes");
             })
         })
     }

--- a/src/network.rs
+++ b/src/network.rs
@@ -389,7 +389,7 @@ mod tests {
     }
     #[test]
     #[should_panic(expected = "number of inputs must match number of nodes in layer 0")]
-    fn set_inupts_too_short() {
+    fn set_inputs_too_short() {
         let mut nw = new_nw();
         let inps = vec![0.9; 4];
         nw.set_inputs(&inps);

--- a/src/network.rs
+++ b/src/network.rs
@@ -231,101 +231,113 @@ mod tests {
     use super::*;
     use crate::test_util::*;
 
-    #[test]
-    fn init_by_shape() {
-        let shape = vec![5, 3, 2];
-        let nw = Network::new(&shape);
-        assert_eq!(nw.layers.len(), shape.len());
-        nw.layers.iter().enumerate().for_each(|(i, l)| {
-            assert_eq!(l.len(), shape[i]);
-        })
-    }
-    #[test]
-    #[should_panic(expected = "network must have at least start and end layers")]
-    fn few_layers_fast_fail() {
-        Network::new(&vec![7]);
-    }
-    #[test]
-    fn nodes_know_self_layer() {
-        let shape = vec![5, 3, 2];
-        let nw = Network::new(&shape);
-        nw.layers.iter().enumerate().skip(1).for_each(|(i, l)| {
-            l.iter().for_each(|n| {
-                assert_eq!(n.try_into_ref::<Node>().unwrap().layer, i);
-            })
-        })
-    }
-    #[test]
-    fn nodes_have_correct_inp_w_length() {
-        let shape = vec![5, 3, 2];
-        let nw = Network::new(&shape);
-        nw.layers.iter().enumerate().skip(1).for_each(|(i, l)| {
-            l.iter().for_each(|n| {
-                assert_eq!(n.try_into_ref::<Node>().unwrap().inp_w.len(), shape[i - 1]);
-            })
-        })
-    }
-    #[test]
-    fn start_layer_has_start_nodes() {
-        let shape = vec![5, 3, 2];
-        let nw = Network::new(&shape);
-        nw.layers[0].iter().for_each(|n| {
-            n.try_into_ref::<StartNode>()
-                .expect("Start layer must only conatin start nodes");
-        })
-    }
-    #[test]
-    fn main_layers_have_main_nodes() {
-        let shape = vec![5, 3, 2];
-        let nw = Network::new(&shape);
-        nw.layers.iter().skip(1).for_each(|l| {
-            l.iter().for_each(|n| {
-                n.try_into_ref::<Node>()
-                    .expect("Main layer must only conatin main nodes");
-            })
-        })
-    }
-    #[test]
-    fn config_built_correctly() {
-        let shape = vec![5, 3, 2];
-        let nw = Network::new(&shape);
-        assert_eq!(
-            nw.config,
-            NetworkConfig {
-                shape: vec![5, 3, 2],
-                ..Default::default()
-            }
-        );
-    }
-    #[test]
-    fn config_arg_respected() {
-        let config = NetworkConfig {
-            learning_rate: 3.5,
-            shape: vec![10, 6, 3],
-        };
-        let nw = Network::with_config(&config);
-        assert_eq!(nw.config, config);
-    }
+    /// Create a network with shape `[5, 3, 2]`
     fn new_nw() -> Network {
         Network::new(&vec![5, 3, 2])
     }
-    #[test]
-    #[should_panic(expected = "Length of expected must match length of output")]
-    fn current_cost_bad_expected_fails() {
-        new_nw().get_current_cost(&vec![0.1; 5]);
+
+    mod test_new {
+        use super::*;
+        
+        #[test]
+        fn init_by_shape() {
+            let shape = vec![5, 3, 2];
+            let nw = Network::new(&shape);
+            assert_eq!(nw.layers.len(), shape.len());
+            nw.layers.iter().enumerate().for_each(|(i, l)| {
+                assert_eq!(l.len(), shape[i]);
+            })
+        }
+        #[test]
+        #[should_panic(expected = "network must have at least start and end layers")]
+        fn few_layers_fast_fail() {
+            Network::new(&vec![7]);
+        }
+        #[test]
+        fn nodes_know_self_layer() {
+            let shape = vec![5, 3, 2];
+            let nw = Network::new(&shape);
+            nw.layers.iter().enumerate().skip(1).for_each(|(i, l)| {
+                l.iter().for_each(|n| {
+                    assert_eq!(n.try_into_ref::<Node>().unwrap().layer, i);
+                })
+            })
+        }
+        #[test]
+        fn nodes_have_correct_inp_w_length() {
+            let shape = vec![5, 3, 2];
+            let nw = Network::new(&shape);
+            nw.layers.iter().enumerate().skip(1).for_each(|(i, l)| {
+                l.iter().for_each(|n| {
+                    assert_eq!(n.try_into_ref::<Node>().unwrap().inp_w.len(), shape[i - 1]);
+                })
+            })
+        }
+        #[test]
+        fn start_layer_has_start_nodes() {
+            let shape = vec![5, 3, 2];
+            let nw = Network::new(&shape);
+            nw.layers[0].iter().for_each(|n| {
+                n.try_into_ref::<StartNode>()
+                    .expect("Start layer must only conatin start nodes");
+            })
+        }
+        #[test]
+        fn main_layers_have_main_nodes() {
+            let shape = vec![5, 3, 2];
+            let nw = Network::new(&shape);
+            nw.layers.iter().skip(1).for_each(|l| {
+                l.iter().for_each(|n| {
+                    n.try_into_ref::<Node>()
+                        .expect("Main layer must only conatin main nodes");
+                })
+            })
+        }
+        #[test]
+        fn config_built_correctly() {
+            let shape = vec![5, 3, 2];
+            let nw = Network::new(&shape);
+            assert_eq!(
+                nw.config,
+                NetworkConfig {
+                    shape: vec![5, 3, 2],
+                    ..Default::default()
+                }
+            );
+        }
+        #[test]
+        fn config_arg_respected() {
+            let config = NetworkConfig {
+                learning_rate: 3.5,
+                shape: vec![10, 6, 3],
+            };
+            let nw = Network::with_config(&config);
+            assert_eq!(nw.config, config);
+        }
     }
-    #[test]
-    fn current_cost_zero() {
-        let mut nw = new_nw();
-        nw.set_inputs(&vec![0.0; 5]);
-        assert_eq!(nw.get_current_cost(&vec![0.5; 2]), 0.0);
+    
+    mod current_cost {
+        use super::*;
+        
+        #[test]
+        #[should_panic(expected = "Length of expected must match length of output")]
+        fn bad_length_fails() {
+            new_nw().get_current_cost(&vec![0.1; 5]);
+        }
+        #[test]
+        fn result_zero() {
+            let mut nw = new_nw();
+            nw.set_inputs(&vec![0.0; 5]);
+            assert_eq!(nw.get_current_cost(&vec![0.5; 2]), 0.0);
+        }
+        #[test]
+        fn result_normal() {
+            let mut nw = Network::new(&vec![7, 5, 5, 2]);
+            nw.set_inputs(&vec![0.0; 7]);
+            assert_f_eq!(nw.get_current_cost(&vec![0.9, 0.31]), 0.1961);
+        }
     }
-    #[test]
-    fn current_cost_normal() {
-        let mut nw = Network::new(&vec![7, 5, 5, 2]);
-        nw.set_inputs(&vec![0.0; 7]);
-        assert_f_eq!(nw.get_current_cost(&vec![0.9, 0.31]), 0.1961);
-    }
+    
     #[test]
     fn test_invaildate() {
         let nw = new_nw();

--- a/src/network.rs
+++ b/src/network.rs
@@ -37,7 +37,7 @@ impl Network {
 
     pub fn with_config(config: &NetworkConfig) -> Network {
         let config = config.clone();
-        assert!(config.shape.len() >= 2);
+        assert!(config.shape.len() >= 2, "network must have at least start and end layers!");
         let layers = config
             .shape
             .iter()
@@ -215,5 +215,26 @@ impl Network {
     #[inline]
     pub fn last_layer(&self) -> &LayerT {
         self.layers.last().expect("Network must have layers!!!")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // use crate::test_util::*;
+
+    #[test]
+    fn init_by_shape() {
+        let shape = vec![5, 3, 2];
+        let nw = Network::new(&shape);
+        assert_eq!(nw.layers.len(), shape.len());
+        nw.layers.iter().enumerate().for_each(|(i, l)| {
+            assert_eq!(l.len(), shape[i]);
+        })
+    }
+    #[test]
+    #[should_panic(expected = "network must have at least start and end layers")]
+    fn few_layers_fast_fail() {
+        Network::new(&vec![7]);
     }
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -101,9 +101,10 @@ impl Network {
 
     pub fn set_inputs(&mut self, inputs: &Vec<f64>) {
         assert_eq!(
-            inputs.len(), 
-            self.layers[0].len(), 
-            "number of inputs must match number of nodes in layer 0");
+            inputs.len(),
+            self.layers[0].len(),
+            "number of inputs must match number of nodes in layer 0"
+        );
         self.layers[0].iter_mut().enumerate().for_each(|(i, n)| {
             n.try_into_ref_mut::<StartNode>()
                 .unwrap()
@@ -238,7 +239,7 @@ mod tests {
 
     mod test_new {
         use super::*;
-        
+
         #[test]
         fn init_by_shape() {
             let shape = vec![5, 3, 2];
@@ -315,10 +316,10 @@ mod tests {
             assert_eq!(nw.config, config);
         }
     }
-    
+
     mod current_cost {
         use super::*;
-        
+
         #[test]
         #[should_panic(expected = "Length of expected must match length of output")]
         fn bad_length_fails() {
@@ -337,7 +338,7 @@ mod tests {
             assert_f_eq!(nw.get_current_cost(&vec![0.9, 0.31]), 0.1961);
         }
     }
-    
+
     #[test]
     fn invaildate() {
         let nw = new_nw();
@@ -362,25 +363,25 @@ mod tests {
 
     mod set_input {
         use super::*;
-        
+
         #[test]
         fn normal() {
             let mut nw = new_nw();
             nw.set_input(3, 0.7);
             assert_eq!(nw.layers[0][3].get_value(&nw), 0.7);
         }
-        
+
         #[test]
         #[should_panic(expected = "6")]
-        fn oob() { // (out of bounds)
+        fn oob() {
             let mut nw = new_nw();
             nw.set_input(6, 0.7);
         }
     }
-    
+
     mod set_inputs {
         use super::*;
-        
+
         #[test]
         fn normal() {
             let mut nw = new_nw();
@@ -390,7 +391,7 @@ mod tests {
                 assert_eq!(n.get_value(&nw), inps[i]);
             })
         }
-        
+
         #[test]
         #[should_panic(expected = "number of inputs must match number of nodes in layer 0")]
         fn too_long() {
@@ -398,7 +399,7 @@ mod tests {
             let inps = vec![0.8; 6];
             nw.set_inputs(&inps);
         }
-        
+
         #[test]
         #[should_panic(expected = "number of inputs must match number of nodes in layer 0")]
         fn too_short() {
@@ -407,7 +408,7 @@ mod tests {
             nw.set_inputs(&inps);
         }
     }
-    
+
     #[test]
     fn get_output_from_cache_forced() {
         let nw = new_nw();
@@ -420,7 +421,7 @@ mod tests {
             assert_eq!(nw.get_output(i), -4.5);
         });
     }
-    
+
     #[test]
     fn get_outputs_from_cache_forced() {
         let nw = new_nw();
@@ -438,7 +439,7 @@ mod tests {
     #[test]
     fn get_outputs_full() {
         use crate::sigmoid::Sigmoid;
-        
+
         let mut nw = Network::new(&vec![3, 2]);
         let inputs = vec![0.9, 0.2, 0.45];
         nw.set_inputs(&inputs);
@@ -449,11 +450,15 @@ mod tests {
             nw.get_main_node_mut(1, ni).bias = biases[ni];
         }
         let actual = nw.get_outputs();
-        let outputs: Vec<_> = (0..2).map(|mni| {
-            (biases[mni] + (0..3).map(|sni| {
-                inputs[sni] * weights[mni][sni]
-            }).sum::<f64>()).sigmoid()
-        }).collect();
+        let outputs: Vec<_> = (0..2)
+            .map(|mni| {
+                ((0..3)
+                    .map(|sni| inputs[sni] * weights[mni][sni])
+                    .sum::<f64>()
+                    + biases[mni])
+                    .sigmoid()
+            })
+            .collect();
         println!("{:#?}", nw);
         assert_eq!(actual, outputs);
     }

--- a/src/network.rs
+++ b/src/network.rs
@@ -277,4 +277,20 @@ mod tests {
             })
         })
     }
+    #[test]
+    fn config_built_correctly() {
+        let shape = vec![5, 3, 2];
+        let nw = Network::new(&shape);
+        assert_eq!(nw.config.shape, shape);
+        assert_eq!(nw.config.learning_rate, NetworkConfig::default().learning_rate);
+    }
+    #[test]
+    fn config_arg_respected() {
+        let nw = Network::with_config(&NetworkConfig {
+            learning_rate: 3.5,
+            shape: vec![10, 6, 3]
+        });
+        assert_eq!(nw.config.learning_rate, 3.5);
+        assert_eq!(nw.config.shape, vec![10, 6, 3]);
+    }
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -343,4 +343,17 @@ mod tests {
             })
         });
     }
+    #[test]
+    fn test_set_input() {
+        let mut nw = new_nw();
+        nw.set_input(3, 0.7);
+        assert_eq!(nw.layers[0][3].get_value(&nw), 0.7);
+    }
+    #[test]
+    #[should_panic(expected = "6")]
+    fn set_input_oob() { // (out of bounds)
+        let mut nw = new_nw();
+        nw.set_input(6, 0.7);
+    }
+    // TODO use mockall crate for mocking???
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -114,9 +114,9 @@ impl Network {
 }
 
 impl Network {
-    pub fn request_nudges_end(&self, expected: &Vec<f64>) {
+    pub fn request_nudges(&self, expected: &Vec<f64>) {
         let outputs = self.get_outputs();
-        self.layers[self.layers.len() - 1]
+        self.last_layer()
             .iter()
             .enumerate()
             .for_each(|(i, n)| {
@@ -129,7 +129,7 @@ impl Network {
     }
 
     pub fn train_on_current_data(&self, expected: &Vec<f64>) {
-        self.request_nudges_end(expected);
+        self.request_nudges(expected);
         self.layers.iter().skip(1).rev().for_each(|l| {
             l.iter().for_each(|n| {
                 n.try_into_ref::<Node>().unwrap().calc_nudge(self);

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,4 +1,4 @@
-use crate::node::{new_node, AnyNode, Node, StartNode};
+use crate::node::{new_node, AnyNode, Node, StartNode, NodeLike};
 use crate::training_data::{TrainingData, TrainingExample};
 use crate::util::{error_deriv, error_f, TryIntoRef, TryIntoRefMut};
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -237,4 +237,24 @@ mod tests {
     fn few_layers_fast_fail() {
         Network::new(&vec![7]);
     }
+    #[test]
+    fn nodes_know_self_layer() {
+        let shape = vec![5, 3, 2];
+        let nw = Network::new(&shape);
+        nw.layers.iter().enumerate().skip(1).for_each(|(i, l)| {
+            l.iter().for_each(|n| {
+                assert_eq!(n.try_into_ref::<Node>().unwrap().layer, i);
+            })
+        })
+    }
+    #[test]
+    fn nodes_have_correct_inp_w_length() {
+        let shape = vec![5, 3, 2];
+        let nw = Network::new(&shape);
+        nw.layers.iter().enumerate().skip(1).for_each(|(i, l)| {
+            l.iter().for_each(|n| {
+                assert_eq!(n.try_into_ref::<Node>().unwrap().inp_w.len(), shape[i - 1]);
+            })
+        })
+    }
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -61,7 +61,11 @@ impl Network {
     }
 
     pub fn get_current_cost(&self, expected: &Vec<f64>) -> f64 {
-        assert_eq!(self.last_layer().len(), expected.len(), "Length of expected must match length of output");
+        assert_eq!(
+            self.last_layer().len(),
+            expected.len(),
+            "Length of expected must match length of output"
+        );
         self.layers[self.layers.len() - 1]
             .iter()
             .enumerate()
@@ -281,19 +285,22 @@ mod tests {
     fn config_built_correctly() {
         let shape = vec![5, 3, 2];
         let nw = Network::new(&shape);
-        assert_eq!(nw.config, NetworkConfig {
-            shape: vec![5, 3, 2],
-            ..Default::default()
-        });
+        assert_eq!(
+            nw.config,
+            NetworkConfig {
+                shape: vec![5, 3, 2],
+                ..Default::default()
+            }
+        );
     }
     #[test]
     fn config_arg_respected() {
         let config = NetworkConfig {
             learning_rate: 3.5,
-            shape: vec![10, 6, 3]
+            shape: vec![10, 6, 3],
         };
         let nw = Network::with_config(&config);
-        assert_eq!(nw.config, config);    
+        assert_eq!(nw.config, config);
     }
     fn new_nw() -> Network {
         Network::new(&vec![5, 3, 2])
@@ -314,5 +321,26 @@ mod tests {
         let mut nw = Network::new(&vec![7, 5, 5, 2]);
         nw.set_inputs(&vec![0.0; 7]);
         assert_f_eq!(nw.get_current_cost(&vec![0.9, 0.31]), 0.1961);
+    }
+    #[test]
+    fn test_invaildate() {
+        let nw = new_nw();
+        // set caches
+        nw.get_outputs();
+        nw.layers.iter().skip(1).for_each(|l| {
+            l.iter().for_each(|n| {
+                let n: &Node = n.try_into_ref().unwrap();
+                assert!(n.sum_cache.borrow().is_some());
+                assert!(n.result_cache.borrow().is_some());
+            })
+        });
+        nw.invalidate();
+        nw.layers.iter().skip(1).for_each(|l| {
+            l.iter().for_each(|n| {
+                let n: &Node = n.try_into_ref().unwrap();
+                assert!(n.sum_cache.borrow().is_none());
+                assert!(n.result_cache.borrow().is_none());
+            })
+        });
     }
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -339,7 +339,7 @@ mod tests {
     }
     
     #[test]
-    fn test_invaildate() {
+    fn invaildate() {
         let nw = new_nw();
         // set caches
         nw.get_outputs();
@@ -359,41 +359,55 @@ mod tests {
             })
         });
     }
-    #[test]
-    fn test_set_input() {
-        let mut nw = new_nw();
-        nw.set_input(3, 0.7);
-        assert_eq!(nw.layers[0][3].get_value(&nw), 0.7);
+
+    mod set_input {
+        use super::*;
+        
+        #[test]
+        fn normal() {
+            let mut nw = new_nw();
+            nw.set_input(3, 0.7);
+            assert_eq!(nw.layers[0][3].get_value(&nw), 0.7);
+        }
+        
+        #[test]
+        #[should_panic(expected = "6")]
+        fn oob() { // (out of bounds)
+            let mut nw = new_nw();
+            nw.set_input(6, 0.7);
+        }
     }
-    #[test]
-    #[should_panic(expected = "6")]
-    fn set_input_oob() { // (out of bounds)
-        let mut nw = new_nw();
-        nw.set_input(6, 0.7);
+    
+    mod set_inputs {
+        use super::*;
+        
+        #[test]
+        fn normal() {
+            let mut nw = new_nw();
+            let inps = vec![0.2; 5];
+            nw.set_inputs(&inps);
+            nw.layers[0].iter().enumerate().for_each(|(i, n)| {
+                assert_eq!(n.get_value(&nw), inps[i]);
+            })
+        }
+        
+        #[test]
+        #[should_panic(expected = "number of inputs must match number of nodes in layer 0")]
+        fn too_long() {
+            let mut nw = new_nw();
+            let inps = vec![0.8; 6];
+            nw.set_inputs(&inps);
+        }
+        
+        #[test]
+        #[should_panic(expected = "number of inputs must match number of nodes in layer 0")]
+        fn too_short() {
+            let mut nw = new_nw();
+            let inps = vec![0.9; 4];
+            nw.set_inputs(&inps);
+        }
     }
-    #[test]
-    fn test_set_inputs() {
-        let mut nw = new_nw();
-        let inps = vec![0.2; 5];
-        nw.set_inputs(&inps);
-        nw.layers[0].iter().enumerate().for_each(|(i, n)| {
-            assert_eq!(n.get_value(&nw), inps[i]);
-        })
-    }
-    #[test]
-    #[should_panic(expected = "number of inputs must match number of nodes in layer 0")]
-    fn set_inputs_too_long() {
-        let mut nw = new_nw();
-        let inps = vec![0.8; 6];
-        nw.set_inputs(&inps);
-    }
-    #[test]
-    #[should_panic(expected = "number of inputs must match number of nodes in layer 0")]
-    fn set_inputs_too_short() {
-        let mut nw = new_nw();
-        let inps = vec![0.9; 4];
-        nw.set_inputs(&inps);
-    }
+    
     #[test]
     fn get_output_from_cache_forced() {
         let nw = new_nw();
@@ -406,6 +420,7 @@ mod tests {
             assert_eq!(nw.get_output(i), -4.5);
         });
     }
+    
     #[test]
     fn get_outputs_from_cache_forced() {
         let nw = new_nw();

--- a/src/network.rs
+++ b/src/network.rs
@@ -257,4 +257,22 @@ mod tests {
             })
         })
     }
+    #[test]
+    fn start_layer_has_start_nodes() {
+        let shape = vec![5, 3, 2];
+        let nw = Network::new(&shape);
+        nw.layers[0].iter().for_each(|n| {
+            n.try_into_ref::<StartNode>().expect("Start layer must only conatin start nodes");
+        })
+    }
+    #[test]
+    fn main_layers_have_main_nodes() {
+        let shape = vec![5, 3, 2];
+        let nw = Network::new(&shape);
+        nw.layers.iter().skip(1).for_each(|l| {
+            l.iter().for_each(|n| {
+                n.try_into_ref::<Node>().expect("Main layer must only conatin main nodes");
+            })
+        })
+    }
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -462,4 +462,22 @@ mod tests {
         println!("{:#?}", nw);
         assert_eq!(actual, outputs);
     }
+
+    #[test]
+    fn request_nudges() {
+        let nw = Network::new(&vec![5, 3, 4]);
+        let outputs = vec![0.8, 0.1, 0.0, 1.0];
+        let expected = vec![0.7, 0.8, 0.0, 0.77];
+        for i in 0..4 {
+            nw.get_main_node(2, i).result_cache.replace(Some(outputs[i]));
+        }
+        let expect_nudges: Vec<_> = (0..4).map(|i| {
+            -error_deriv(outputs[i], expected[i])
+        }).collect();
+        nw.request_nudges(&expected);
+        for i in 0..4 {
+            let node = nw.get_main_node(2, i);
+            assert_eq!(*node.requested_nudge.borrow(), expect_nudges[i]);
+        }
+    }
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -359,7 +359,6 @@ mod tests {
         let mut nw = new_nw();
         nw.set_input(6, 0.7);
     }
-    // TODO use mockall crate for mocking???
     #[test]
     fn test_set_inputs() {
         let mut nw = new_nw();
@@ -382,5 +381,30 @@ mod tests {
         let mut nw = new_nw();
         let inps = vec![0.9; 4];
         nw.set_inputs(&inps);
+    }
+    #[test]
+    fn get_output_from_cache_forced() {
+        let nw = new_nw();
+        (0..*nw.config.shape.last().unwrap()).for_each(|i| {
+            nw.last_layer()[i]
+                .try_into_ref::<Node>()
+                .unwrap()
+                .result_cache
+                .replace(Some(-4.5));
+            assert_eq!(nw.get_output(i), -4.5);
+        });
+    }
+    #[test]
+    fn get_outputs_from_cache_forced() {
+        let nw = new_nw();
+        let out_cnt = *nw.config.shape.last().unwrap();
+        (0..out_cnt).for_each(|i| {
+            nw.last_layer()[i]
+                .try_into_ref::<Node>()
+                .unwrap()
+                .result_cache
+                .replace(Some(0.2));
+        });
+        assert_eq!(nw.get_outputs(), vec![0.2; out_cnt]);
     }
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -100,6 +100,10 @@ impl Network {
     }
 
     pub fn set_inputs(&mut self, inputs: &Vec<f64>) {
+        assert_eq!(
+            inputs.len(), 
+            self.layers[0].len(), 
+            "number of inputs must match number of nodes in layer 0");
         self.layers[0].iter_mut().enumerate().for_each(|(i, n)| {
             n.try_into_ref_mut::<StartNode>()
                 .unwrap()
@@ -356,4 +360,27 @@ mod tests {
         nw.set_input(6, 0.7);
     }
     // TODO use mockall crate for mocking???
+    #[test]
+    fn test_set_inputs() {
+        let mut nw = new_nw();
+        let inps = vec![0.2; 5];
+        nw.set_inputs(&inps);
+        nw.layers[0].iter().enumerate().for_each(|(i, n)| {
+            assert_eq!(n.get_value(&nw), inps[i]);
+        })
+    }
+    #[test]
+    #[should_panic(expected = "number of inputs must match number of nodes in layer 0")]
+    fn set_inputs_too_long() {
+        let mut nw = new_nw();
+        let inps = vec![0.8; 6];
+        nw.set_inputs(&inps);
+    }
+    #[test]
+    #[should_panic(expected = "number of inputs must match number of nodes in layer 0")]
+    fn set_inupts_too_short() {
+        let mut nw = new_nw();
+        let inps = vec![0.9; 4];
+        nw.set_inputs(&inps);
+    }
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -5,7 +5,7 @@ use crate::util::{error_deriv, error_f, TryIntoRef, TryIntoRefMut};
 pub type LayerT = Vec<AnyNode>;
 pub type NetworkLayersT = Vec<LayerT>;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct NetworkConfig {
     pub learning_rate: f64,
     pub shape: Vec<usize>,
@@ -281,16 +281,18 @@ mod tests {
     fn config_built_correctly() {
         let shape = vec![5, 3, 2];
         let nw = Network::new(&shape);
-        assert_eq!(nw.config.shape, shape);
-        assert_eq!(nw.config.learning_rate, NetworkConfig::default().learning_rate);
+        assert_eq!(nw.config, NetworkConfig {
+            shape: vec![5, 3, 2],
+            ..Default::default()
+        });
     }
     #[test]
     fn config_arg_respected() {
-        let nw = Network::with_config(&NetworkConfig {
+        let config = NetworkConfig {
             learning_rate: 3.5,
             shape: vec![10, 6, 3]
-        });
-        assert_eq!(nw.config.learning_rate, 3.5);
-        assert_eq!(nw.config.shape, vec![10, 6, 3]);
+        };
+        let nw = Network::with_config(&config);
+        assert_eq!(nw.config, config);    
     }
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -434,4 +434,27 @@ mod tests {
         });
         assert_eq!(nw.get_outputs(), vec![0.2; out_cnt]);
     }
+
+    #[test]
+    fn get_outputs_full() {
+        use crate::sigmoid::Sigmoid;
+        
+        let mut nw = Network::new(&vec![3, 2]);
+        let inputs = vec![0.9, 0.2, 0.45];
+        nw.set_inputs(&inputs);
+        let weights = vec![vec![-2.3, 0.7, 0.0], vec![0.3, -1.92, -0.14]];
+        let biases = vec![1.1, -0.3];
+        for (ni, v) in weights.iter().enumerate() {
+            nw.get_main_node_mut(1, ni).inp_w.clone_from(v);
+            nw.get_main_node_mut(1, ni).bias = biases[ni];
+        }
+        let actual = nw.get_outputs();
+        let outputs: Vec<_> = (0..2).map(|mni| {
+            (biases[mni] + (0..3).map(|sni| {
+                inputs[sni] * weights[mni][sni]
+            }).sum::<f64>()).sigmoid()
+        }).collect();
+        println!("{:#?}", nw);
+        assert_eq!(actual, outputs);
+    }
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -61,7 +61,7 @@ impl Network {
     }
 
     pub fn get_current_cost(&self, expected: &Vec<f64>) -> f64 {
-        assert_eq!(self.layers.len(), expected.len());
+        assert_eq!(self.last_layer().len(), expected.len(), "Length of expected must match length of output");
         self.layers[self.layers.len() - 1]
             .iter()
             .enumerate()
@@ -221,7 +221,7 @@ impl Network {
 #[cfg(test)]
 mod tests {
     use super::*;
-    // use crate::test_util::*;
+    use crate::test_util::*;
 
     #[test]
     fn init_by_shape() {
@@ -294,5 +294,25 @@ mod tests {
         };
         let nw = Network::with_config(&config);
         assert_eq!(nw.config, config);    
+    }
+    fn new_nw() -> Network {
+        Network::new(&vec![5, 3, 2])
+    }
+    #[test]
+    #[should_panic(expected = "Length of expected must match length of output")]
+    fn current_cost_bad_expected_fails() {
+        new_nw().get_current_cost(&vec![0.1; 5]);
+    }
+    #[test]
+    fn current_cost_zero() {
+        let mut nw = new_nw();
+        nw.set_inputs(&vec![0.0; 5]);
+        assert_eq!(nw.get_current_cost(&vec![0.5; 2]), 0.0);
+    }
+    #[test]
+    fn current_cost_normal() {
+        let mut nw = Network::new(&vec![7, 5, 5, 2]);
+        nw.set_inputs(&vec![0.0; 7]);
+        assert_f_eq!(nw.get_current_cost(&vec![0.9, 0.31]), 0.1961);
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -6,7 +6,6 @@ use std::cell::RefCell;
 pub type AnyNode = Box<dyn NodeLike>;
 pub type AnyNodeLT<'a> = Box<dyn NodeLike + 'a>;
 
-
 pub trait NodeLike: AsAny + std::fmt::Debug {
     fn get_value(&self, network: &Network) -> f64;
 
@@ -28,7 +27,10 @@ impl TryIntoRefMut for dyn NodeLike {
     }
 }
 
-pub fn new_node<'a, T>(n: T) -> AnyNodeLT<'a> where T: NodeLike + 'a {
+pub fn new_node<'a, T>(n: T) -> AnyNodeLT<'a>
+where
+    T: NodeLike + 'a,
+{
     Box::new(n) as AnyNodeLT
 }
 
@@ -101,9 +103,13 @@ impl Node {
     pub fn apply_nudges(&mut self) {
         let inv_cnt = 1.0 / (*self.nudge_cnt.borrow() as f64);
         self.bias += *self.bias_nudge_sum.borrow() * inv_cnt;
-        self.inp_w_nudge_sum.borrow().iter().enumerate().for_each(|(i, wn)| {
-            self.inp_w[i] += wn * inv_cnt;
-        });
+        self.inp_w_nudge_sum
+            .borrow()
+            .iter()
+            .enumerate()
+            .for_each(|(i, wn)| {
+                self.inp_w[i] += wn * inv_cnt;
+            });
     }
 
     pub fn clear_nudges(&mut self) {

--- a/src/node.rs
+++ b/src/node.rs
@@ -392,5 +392,14 @@ mod tests {
                 assert_eq!(n.get_value(&nw), expected);
             }
         }
+
+        #[test]
+        fn request_nudge() {
+            let n = Node::new(0.2, &vec![2.1, -0.3], 1);
+            n.request_nudge(3.1);
+            assert_refcell_eq!(n.requested_nudge, 3.1);
+            n.request_nudge(-0.8);
+            assert_refcell_eq!(n.requested_nudge, 3.1 - 0.8);
+        }
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -117,7 +117,7 @@ impl Node {
     }
 
     pub fn get_sum(&self, network: &Network) -> f64 {
-        if let Some(cached) = *self.result_cache.borrow() {
+        if let Some(cached) = *self.sum_cache.borrow() {
             return cached;
         }
         let inp_sum = self

--- a/src/node.rs
+++ b/src/node.rs
@@ -241,5 +241,23 @@ mod tests {
             assert_refcell_eq!(n.bias_nudge_sum, 0.0);
             assert_refcell_eq!(n.inp_w_nudge_sum, vec![0.0; 2]);
         }
+
+        #[test]
+        fn is_last_layer_in_network() {
+            let nw = Network::new(&vec![1, 2, 3]);
+            let n = nw.get_main_node(2, 1);
+            assert_eq!(n.is_last_layer(&nw), true);
+            let n = nw.get_main_node(1, 0);
+            assert_eq!(n.is_last_layer(&nw), false);
+        }
+
+        #[test]
+        fn is_last_layer_indep() {
+            let nw = Network::new(&vec![1, 2, 3]);
+            let n = Node::new(0.2, &vec![2.1, -0.3], 2);
+            assert_eq!(n.is_last_layer(&nw), true);
+            let n = Node::new(0.2, &vec![-9.8], 1);
+            assert_eq!(n.is_last_layer(&nw), false);
+        }
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -4,6 +4,8 @@ use crate::util::{impl_as_any, AsAny, TryIntoRef, TryIntoRefMut};
 use std::cell::RefCell;
 
 pub type AnyNode = Box<dyn NodeLike>;
+pub type AnyNodeLT<'a> = Box<dyn NodeLike + 'a>;
+
 
 pub trait NodeLike: AsAny + std::fmt::Debug {
     fn get_value(&self, network: &Network) -> f64;
@@ -26,8 +28,8 @@ impl TryIntoRefMut for dyn NodeLike {
     }
 }
 
-pub fn new_node<T: NodeLike + 'static>(n: T) -> AnyNode {
-    Box::new(n) as AnyNode
+pub fn new_node<'a, T>(n: T) -> AnyNodeLT<'a> where T: NodeLike + 'a {
+    Box::new(n) as AnyNodeLT
 }
 
 #[derive(Debug)]

--- a/src/node.rs
+++ b/src/node.rs
@@ -168,4 +168,49 @@ impl StartNode {
     pub fn set_value(&mut self, value: f64) {
         self.value = value;
     }
+
+    pub fn get_start_value(&self) -> f64 {
+        // same as `get_value` but doesn't require `Network` as argument
+        // the different naming is because rust can't differentiate properly
+        // between a 0-arg `get_value` defined on the struct and a 1-arg
+        // `get_value` defined on the `NodeLike` trait
+        self.value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    mod start_node {
+        use super::*;
+        use crate::network::Network;
+        
+        #[test]
+        fn test_new() {
+            let n = StartNode::new(0.7);
+            assert_eq!(n.value, 0.7);
+        }
+
+        #[test]
+        fn set_value() {
+            let mut n = StartNode::new(3.3);
+            n.set_value(0.1);
+            assert_eq!(n.value, 0.1);
+        }
+
+        #[test]
+        fn get_value() {
+            // not very clean, but `get_value` needs a argument of type `Network`
+            let mut nw = Network::new(&vec![1, 1]);
+            nw.get_start_node_mut(0).value = -1.9;
+            assert_eq!(nw.get_node(0, 0).get_value(&nw), -1.9);
+        }
+
+        #[test]
+        fn get_value_start() {
+            let n = StartNode::new(8.7);
+            assert_eq!(n.get_start_value(), 8.7);
+        }
+    }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -86,21 +86,11 @@ impl Node {
                 base_nudge * network.get_node(self.layer - 1, i).get_value(network);
             
             // nudge previous nodes
-            // this doesn't appear to work: WHY?
-            // network
-            //     .get_node(self.layer - 1, i)
-            //     .request_nudge(base_nudge * self.inp_w[i]);
-            if self.layer > 1 {
-                *network.get_node(self.layer - 1, i)
-                    .try_into_ref::<Node>().unwrap()
-                    .requested_nudge.borrow_mut() += base_nudge * self.inp_w[i];
-            }
+            network
+                .get_node(self.layer - 1, i)
+                .request_nudge(base_nudge * self.inp_w[i]);
         });
         (*self.nudge_cnt.borrow_mut()) += 1;
-    }
-
-    pub fn request_nudge(&self, nudge: f64) {
-        *self.requested_nudge.borrow_mut() += nudge;
     }
 
     pub fn apply_nudges(&mut self) {
@@ -155,6 +145,10 @@ impl NodeLike for Node {
     fn invalidate(&self) {
         self.sum_cache.replace(None);
         self.result_cache.replace(None);
+    }
+
+    fn request_nudge(&self, nudge: f64) {
+        *self.requested_nudge.borrow_mut() += nudge;
     }
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -111,6 +111,7 @@ impl Node {
     pub fn clear_nudges(&mut self) {
         self.nudge_cnt.replace(0);
         self.bias_nudge_sum.replace(0.0);
+        // or .borrow_mut().fill(0.0)
         self.inp_w_nudge_sum.replace(vec![0.0; self.inp_w.len()]);
         self.requested_nudge.replace(0.0);
     }
@@ -181,6 +182,7 @@ impl StartNode {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_util::assert_refcell_eq;
     
     mod start_node {
         use super::*;
@@ -211,6 +213,33 @@ mod tests {
         fn get_value_start() {
             let n = StartNode::new(8.7);
             assert_eq!(n.get_start_value(), 8.7);
+        }
+    }
+
+    mod main_node {
+        use super::*;
+        
+        #[test]
+        fn new_params() {
+            let n = Node::new(2.1, &vec![0.4, -7.4], 4);
+            assert_eq!(n.bias, 2.1);
+            assert_eq!(n.inp_w, vec![0.4, -7.4]);
+            assert_eq!(n.layer, 4);
+        }
+
+        #[test]
+        fn new_cache() {
+            let n = Node::new(2.1, &vec![0.4, -7.4], 4);
+            assert_refcell_eq!(n.result_cache, None);
+            assert_refcell_eq!(n.result_cache, None);
+        }
+
+        #[test]
+        fn new_nudges() {
+            let n = Node::new(2.1, &vec![0.4, -7.4], 4);
+            assert_refcell_eq!(n.nudge_cnt, 0);
+            assert_refcell_eq!(n.bias_nudge_sum, 0.0);
+            assert_refcell_eq!(n.inp_w_nudge_sum, vec![0.0; 2]);
         }
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -63,10 +63,6 @@ impl Node {
             requested_nudge: RefCell::new(0.0),
         };
     }
-    pub fn invalidate(&self) {
-        self.sum_cache.replace(None);
-        self.result_cache.replace(None);
-    }
 
     pub fn is_last_layer(&self, network: &Network) -> bool {
         self.layer == network.n_layers() - 1
@@ -146,6 +142,11 @@ impl NodeLike for Node {
         let val = inp_sum.sigmoid();
         self.result_cache.replace(Some(val));
         return val;
+    }
+
+    fn invalidate(&self) {
+        self.sum_cache.replace(None);
+        self.result_cache.replace(None);
     }
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -218,6 +218,11 @@ mod tests {
 
     mod main_node {
         use super::*;
+
+        /// Makes network with shape `[3, 5, 4, 2]`
+        fn make_nw() -> Network {
+            return Network::new(&vec![3, 5, 4, 2]);
+        }
         
         #[test]
         fn new_params() {
@@ -302,6 +307,18 @@ mod tests {
             n.result_cache.replace(Some(-0.8));
             n.invalidate();
             assert_refcell_eq!(n.result_cache, None);
+        }
+
+        mod get_sum {
+            use super::*;
+
+            #[test]
+            fn uses_cached() {
+                let nw = make_nw();
+                let n = nw.get_main_node(2, 1);
+                n.sum_cache.replace(Some(-77.6));
+                assert_eq!(n.get_sum(&nw), -77.6);
+            }
         }
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -183,11 +183,11 @@ impl StartNode {
 mod tests {
     use super::*;
     use crate::test_util::assert_refcell_eq;
-    
+
     mod start_node {
         use super::*;
         use crate::network::Network;
-        
+
         #[test]
         fn test_new() {
             let n = StartNode::new(0.7);
@@ -223,7 +223,7 @@ mod tests {
         fn make_nw() -> Network {
             return Network::new(&vec![3, 5, 4, 2]);
         }
-        
+
         #[test]
         fn new_params() {
             let n = Node::new(2.1, &vec![0.4, -7.4], 4);
@@ -267,7 +267,7 @@ mod tests {
 
         mod inp_w {
             use super::*;
-            
+
             #[test]
             fn get_weight() {
                 let n = Node::new(0.0, &vec![1.0, -0.2, 0.0], 1);
@@ -331,9 +331,9 @@ mod tests {
                 let mut n = nw.get_main_node_mut(1, 2);
                 n.bias = 0.5;
                 n.inp_w = vec![2.3, -1.2, 0.6];
-                n.sum_cache.replace(None);  // ensure not cached
+                n.sum_cache.replace(None); // ensure not cached
                 let n = nw.get_main_node(1, 2);
-                let expected = 0.4*2.3-0.8*1.2+0.1*0.6+0.5;
+                let expected = 0.4 * 2.3 - 0.8 * 1.2 + 0.1 * 0.6 + 0.5;
                 assert_eq!(n.get_sum(&nw), expected);
             }
 
@@ -344,7 +344,7 @@ mod tests {
                 let mut n = nw.get_main_node_mut(1, 2);
                 n.bias = 0.5;
                 n.inp_w = vec![2.3, -1.2, 0.6];
-                n.sum_cache.replace(None);  // ensure not cached
+                n.sum_cache.replace(None); // ensure not cached
                 let n = nw.get_main_node(1, 2);
                 let value = n.get_sum(&nw);
                 assert_refcell_eq!(n.sum_cache, Some(value));
@@ -386,9 +386,9 @@ mod tests {
                 let mut n = nw.get_main_node_mut(1, 2);
                 n.bias = -3.5;
                 n.inp_w = vec![2.3, -1.2, 0.6];
-                n.invalidate();  // ensure nothing cached
+                n.invalidate(); // ensure nothing cached
                 let n = nw.get_main_node(1, 2);
-                let expected = (0.9*2.3-0.0*1.2+0.1*0.6-3.5).sigmoid();
+                let expected = (0.9 * 2.3 - 0.0 * 1.2 + 0.1 * 0.6 - 3.5).sigmoid();
                 assert_eq!(n.get_value(&nw), expected);
             }
         }

--- a/src/node.rs
+++ b/src/node.rs
@@ -259,5 +259,33 @@ mod tests {
             let n = Node::new(0.2, &vec![-9.8], 1);
             assert_eq!(n.is_last_layer(&nw), false);
         }
+
+        #[test]
+        fn get_weight() {
+            let n = Node::new(0.0, &vec![1.0, -0.2, 0.0], 1);
+            assert_eq!(n.get_weight(0), 1.0);
+            assert_eq!(n.get_weight(2), 0.0);
+        }
+
+        #[test]
+        #[should_panic]
+        fn get_weight_oob() {
+            let n = Node::new(0.0, &vec![1.0, -0.2, 0.0], 1);
+            n.get_weight(3);
+        }
+
+        #[test]
+        fn set_weight() {
+            let mut n = Node::new(0.0, &vec![1.0, -0.2, 0.0], 1);
+            n.set_weight(2, 3.4);
+            assert_eq!(n.inp_w[2], 3.4);
+        }
+
+        #[test]
+        #[should_panic]
+        fn set_weight_oob() {
+            let mut n = Node::new(0.0, &vec![1.0, -0.2, 0.0], 1);
+            n.set_weight(3, 3.4);
+        }
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -108,7 +108,7 @@ impl Node {
             });
     }
 
-    pub fn clear_nudges(&mut self) {
+    pub fn clear_nudges(&self) {
         self.nudge_cnt.replace(0);
         self.bias_nudge_sum.replace(0.0);
         // or .borrow_mut().fill(0.0)
@@ -400,6 +400,20 @@ mod tests {
             assert_refcell_eq!(n.requested_nudge, 3.1);
             n.request_nudge(-0.8);
             assert_refcell_eq!(n.requested_nudge, 3.1 - 0.8);
+        }
+
+        #[test]
+        fn clear_nudges() {
+            let n = Node::new(1.2, &vec![2.2, -0.33], 2);
+            n.bias_nudge_sum.replace(7.998);
+            n.inp_w_nudge_sum.replace(vec![3.1, -2.8]);
+            n.requested_nudge.replace(-3.02);
+            n.nudge_cnt.replace(6);
+            n.clear_nudges();
+            assert_refcell_eq!(n.nudge_cnt, 0);
+            assert_refcell_eq!(n.bias_nudge_sum, 0.0);
+            assert_refcell_eq!(n.inp_w_nudge_sum, vec![0.0; 2]);
+            assert_refcell_eq!(n.requested_nudge, 0.0);
         }
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -76,7 +76,7 @@ impl Node {
     }
 
     pub fn calc_nudge(&self, network: &Network) {
-        let d_sig = self.get_sum(network);
+        let d_sig = self.get_sum(network).sig_deriv();
         let base_nudge = *self.requested_nudge.borrow() * d_sig * network.config.learning_rate;
         // bias nudge
         *self.bias_nudge_sum.borrow_mut() += base_nudge;

--- a/src/node.rs
+++ b/src/node.rs
@@ -319,6 +319,32 @@ mod tests {
                 n.sum_cache.replace(Some(-77.6));
                 assert_eq!(n.get_sum(&nw), -77.6);
             }
+
+            #[test]
+            fn sums_prev_layer_and_bias() {
+                let mut nw = make_nw();
+                nw.set_inputs(&vec![0.4, 0.8, 0.1]);
+                let mut n = nw.get_main_node_mut(1, 2);
+                n.bias = 0.5;
+                n.inp_w = vec![2.3, -1.2, 0.6];
+                n.sum_cache.replace(None);  // ensure not cached
+                let n = nw.get_main_node(1, 2);
+                let expected = 0.4*2.3-0.8*1.2+0.1*0.6+0.5;
+                assert_eq!(n.get_sum(&nw), expected);
+            }
+
+            #[test]
+            fn sets_cache() {
+                let mut nw = make_nw();
+                nw.set_inputs(&vec![0.4, 0.8, 0.1]);
+                let mut n = nw.get_main_node_mut(1, 2);
+                n.bias = 0.5;
+                n.inp_w = vec![2.3, -1.2, 0.6];
+                n.sum_cache.replace(None);  // ensure not cached
+                let n = nw.get_main_node(1, 2);
+                let value = n.get_sum(&nw);
+                assert_refcell_eq!(n.sum_cache, Some(value));
+            }
         }
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -287,5 +287,21 @@ mod tests {
             let mut n = Node::new(0.0, &vec![1.0, -0.2, 0.0], 1);
             n.set_weight(3, 3.4);
         }
+
+        #[test]
+        fn invalidate_sum_cache() {
+            let n = Node::new(2.1, &vec![0.4, -7.4], 2);
+            n.sum_cache.replace(Some(-0.8));
+            n.invalidate();
+            assert_refcell_eq!(n.sum_cache, None);
+        }
+
+        #[test]
+        fn invalidate_result_cache() {
+            let n = Node::new(2.1, &vec![0.4, -7.4], 2);
+            n.result_cache.replace(Some(-0.8));
+            n.invalidate();
+            assert_refcell_eq!(n.result_cache, None);
+        }
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -415,5 +415,20 @@ mod tests {
             assert_refcell_eq!(n.inp_w_nudge_sum, vec![0.0; 2]);
             assert_refcell_eq!(n.requested_nudge, 0.0);
         }
+
+        #[test]
+        fn calc_nudge_layer1() {
+            let mut nw = Network::new(&vec![3, 2]);
+            nw.set_inputs(&vec![0.8, 0.12, 0.53]);
+            let n = nw.get_main_node(1, 1);
+            n.request_nudge(0.9);
+            n.sum_cache.replace(Some(-0.8));
+            n.calc_nudge(&nw);
+            let base_nudge = 0.9 * (-0.8).sig_deriv() * 1.0;
+            assert_refcell_eq!(n.bias_nudge_sum, base_nudge);
+            assert_refcell_eq!(n.inp_w_nudge_sum, vec![
+                base_nudge * 0.8, base_nudge * 0.12, base_nudge * 0.53]);
+            assert_refcell_eq!(n.nudge_cnt, 1);
+        }
     }
 }

--- a/src/sigmoid.rs
+++ b/src/sigmoid.rs
@@ -22,3 +22,39 @@ impl Sigmoid for f64 {
         return s * (1.0 - s);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_util::*;
+
+    #[test]
+    fn sig_f32() {
+        assert_f_eq!(0.0_f32.sigmoid(), 0.5_f32);
+        assert_f_eq!(1.5_f32.sigmoid(), 0.8175744_f32);
+    }
+    #[test]
+    fn sig_f64() {
+        assert_f_eq!(0.0_f64.sigmoid(), 0.5_f64);
+        assert_f_eq!(1.5_f64.sigmoid(), 0.8175744761936437_f64);
+    }
+    #[test]
+    fn sig_deriv_f32() {
+        assert_f_eq!(0.0_f32.sig_deriv(), 0.25_f32);
+        assert_f_eq!((-1.8_f32).sig_deriv(), 0.121729344_f32);
+    }
+    #[test]
+    fn sig_deriv_f64() {
+        assert_f_eq!(0.0_f64.sig_deriv(), 0.25_f64);
+        assert_f_eq!((-1.8_f64).sig_deriv(), 0.12172934028708539_f64);
+    }
+    // this is more of a test for my util funcs than of functionality
+    for_f_types!(sig_inf, {
+        assert_f_eq!(FT::INFINITY.sigmoid(), 1.0);
+        assert_f_eq!(FT::NEG_INFINITY.sigmoid(), 0.0);
+    });
+    for_f_types!(sig_deriv_inf, {
+        assert_f_eq!(FT::INFINITY.sig_deriv(), 0.0);
+        assert_f_eq!(FT::NEG_INFINITY.sig_deriv(), 0.0);
+    });
+}

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -40,6 +40,13 @@ macro_rules! assert_f_eq {
 }
 pub(crate) use assert_f_eq;
 
+macro_rules! assert_refcell_eq {
+    ($refcell: expr, $value: expr) => {
+        assert_eq!(*$refcell.borrow(), $value)
+    };
+}
+pub(crate) use assert_refcell_eq;
+
 macro_rules! for_f_types {
     ($name:ident, $test:block) => {
         #[allow(unused_imports)]

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,0 +1,61 @@
+pub(crate) trait GetEpsilon {
+    fn epsilon(&self) -> Self;
+}
+macro_rules! epsilon_impl {
+    ( $( $t:ty ),+ ) => {
+        $(
+            impl GetEpsilon for $t {
+                fn epsilon(&self) -> Self {
+                    <$t>::EPSILON
+                }
+            }
+        )+
+    };
+}
+epsilon_impl!(f32, f64);
+
+macro_rules! assert_f_eq {
+    (@to_bool $a:expr, $b:expr) => {
+        {
+            let __a = $a;
+            let __b = $b;
+            // NaN != NaN workaround
+            let __b_nan = (__b as f64).is_nan();
+            let __a_nan = (__a as f64).is_nan();
+            if __a_nan || __b_nan { __a_nan && __b_nan }
+            else {
+                __a == __b || ((__a - __b).abs() / __b <= (__b.epsilon() * 4.0))
+            }
+        }
+    };
+    ($a:expr, $b:expr $(, $rest:tt )?) => {
+        {
+            let __a = $a;
+            let __b = $b;
+            if(!assert_f_eq!(@to_bool __a, __b)){
+                assert_eq!(__a, __b $($rest)?);
+            }
+        }
+    }
+}
+pub(crate) use assert_f_eq;
+
+macro_rules! for_f_types {
+    ($name:ident, $test:block) => {
+        #[allow(unused_imports)]
+        mod $name {
+            use super::*;
+            #[test]
+            fn test_f32() {
+                type FT = f32;
+                $test
+            }
+            #[test]
+            fn test_f64() {
+                type FT = f64;
+                $test
+            }
+        }
+    };
+}
+pub(crate) use for_f_types;

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -20,8 +20,8 @@ macro_rules! assert_f_eq {
             let __a = $a;
             let __b = $b;
             // NaN != NaN workaround
-            let __b_nan = (__b as f64).is_nan();
-            let __a_nan = (__a as f64).is_nan();
+            let __a_nan = __a != __a;
+            let __b_nan = __b != __b;
             if __a_nan || __b_nan { __a_nan && __b_nan }
             else {
                 __a == __b || ((__a - __b).abs() / __b <= (__b.epsilon() * 4.0))

--- a/src/training_data.rs
+++ b/src/training_data.rs
@@ -1,20 +1,23 @@
 #[derive(Debug, Clone, PartialEq)]
 pub struct TrainingExample {
     pub inputs: Vec<f64>,
-    pub expected: Vec<f64>
+    pub expected: Vec<f64>,
 }
 
 impl TrainingExample {
     pub fn new(inputs: &Vec<f64>, expected: &Vec<f64>) -> TrainingExample {
-        TrainingExample {inputs: inputs.clone(), expected: expected.clone()}
+        TrainingExample {
+            inputs: inputs.clone(),
+            expected: expected.clone(),
+        }
     }
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct TrainingData (pub Vec<TrainingExample>);
+pub struct TrainingData(pub Vec<TrainingExample>);
 
 impl TrainingData {
-    pub fn chunks(&self, size: usize) -> Vec<TrainingData>{
+    pub fn chunks(&self, size: usize) -> Vec<TrainingData> {
         self.iter_chunks(size).collect()
     }
 
@@ -27,27 +30,42 @@ impl TrainingData {
 mod tests {
     use super::*;
     fn get_tr_data(len: usize) -> TrainingData {
-        TrainingData((0..len).map(|i| {
-            let i = i as f64;
-            let len = len as f64;
-            // just some pseudo-random garbage
-            TrainingExample::new(
-                &vec![i, len], 
-                &vec![i + 0.5])
-        }).collect())
+        TrainingData(
+            (0..len)
+                .map(|i| {
+                    let i = i as f64;
+                    let len = len as f64;
+                    // just some pseudo-random garbage
+                    TrainingExample::new(&vec![i, len], &vec![i + 0.5])
+                })
+                .collect(),
+        )
     }
     #[test]
     fn iter_chunks() {
         let data = get_tr_data(24);
         let chunks_iter = data.iter_chunks(10);
         let chunks: Vec<_> = chunks_iter.collect();
-        assert_eq!(chunks, vec![TrainingData(data.0[0..10].to_vec()), TrainingData(data.0[10..20].to_vec()), TrainingData(data.0[20..].to_vec())]);
+        assert_eq!(
+            chunks,
+            vec![
+                TrainingData(data.0[0..10].to_vec()),
+                TrainingData(data.0[10..20].to_vec()),
+                TrainingData(data.0[20..].to_vec())
+            ]
+        );
     }
     #[test]
     fn get_chunks() {
         let data = get_tr_data(24);
         let chunks = data.chunks(10);
-        assert_eq!(chunks, vec![TrainingData(data.0[0..10].to_vec()), TrainingData(data.0[10..20].to_vec()), TrainingData(data.0[20..].to_vec())]);
+        assert_eq!(
+            chunks,
+            vec![
+                TrainingData(data.0[0..10].to_vec()),
+                TrainingData(data.0[10..20].to_vec()),
+                TrainingData(data.0[20..].to_vec())
+            ]
+        );
     }
 }
-

--- a/src/training_data.rs
+++ b/src/training_data.rs
@@ -37,10 +37,16 @@ mod tests {
         }).collect())
     }
     #[test]
-    fn test_iter_chunks() {
+    fn iter_chunks() {
         let data = get_tr_data(24);
         let chunks_iter = data.iter_chunks(10);
         let chunks: Vec<_> = chunks_iter.collect();
+        assert_eq!(chunks, vec![TrainingData(data.0[0..10].to_vec()), TrainingData(data.0[10..20].to_vec()), TrainingData(data.0[20..].to_vec())]);
+    }
+    #[test]
+    fn get_chunks() {
+        let data = get_tr_data(24);
+        let chunks = data.chunks(10);
         assert_eq!(chunks, vec![TrainingData(data.0[0..10].to_vec()), TrainingData(data.0[10..20].to_vec()), TrainingData(data.0[20..].to_vec())]);
     }
 }

--- a/src/training_data.rs
+++ b/src/training_data.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct TrainingExample {
     pub inputs: Vec<f64>,
     pub expected: Vec<f64>
@@ -10,7 +10,7 @@ impl TrainingExample {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct TrainingData (pub Vec<TrainingExample>);
 
 impl TrainingData {
@@ -20,6 +20,28 @@ impl TrainingData {
 
     pub fn iter_chunks(&self, size: usize) -> impl Iterator<Item = TrainingData> + '_ {
         self.0.chunks(size).map(|c| TrainingData(c.to_vec()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn get_tr_data(len: usize) -> TrainingData {
+        TrainingData((0..len).map(|i| {
+            let i = i as f64;
+            let len = len as f64;
+            // just some pseudo-random garbage
+            TrainingExample::new(
+                &vec![i, len], 
+                &vec![i + 0.5])
+        }).collect())
+    }
+    #[test]
+    fn test_iter_chunks() {
+        let data = get_tr_data(24);
+        let chunks_iter = data.iter_chunks(10);
+        let chunks: Vec<_> = chunks_iter.collect();
+        assert_eq!(chunks, vec![TrainingData(data.0[0..10].to_vec()), TrainingData(data.0[10..20].to_vec()), TrainingData(data.0[20..].to_vec())]);
     }
 }
 


### PR DESCRIPTION
Add unittests, fixes #9. 
Tests for:
- [x] Sigmoid function implementation
- [x] Training data structs
- [x] Network initialisation
- [x] Node forward-propagation
- [x] Network forward-propagation
- [x] Node back-propagation
- [ ] Network back-propagation
- [ ] Applying data from back-propagation